### PR TITLE
Remove default _hookTimeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,11 +62,6 @@ module.exports = function (sails) {
      */
     defaults: {
 
-      // 2 minutes.  You get 2 minutes.
-      grunt: {
-        _hookTimeout: 120000
-      }
-
     },
 
 


### PR DESCRIPTION
This `_hookTimeout` default currently takes precedence over the Sails global `hookTimeout`.